### PR TITLE
代行情報のcrawl対象に川崎を追加

### DIFF
--- a/lib/satone/command/konami_alternate_notifier.rb
+++ b/lib/satone/command/konami_alternate_notifier.rb
@@ -24,6 +24,10 @@ module Satone
         { url: "#{INFORMATION_URL_PREFIX}timetable.php?Facility_cd=004070",
           name: "コナミスポーツクラブ 武蔵小杉",
           file_prefix: "musashikosugi"
+        },
+        { url: "#{INFORMATION_URL_PREFIX}timetable.php?Facility_cd=004479",
+          name: "コナミスポーツクラブ 川崎",
+          file_prefix: "kawasaki"
         }
       ]
 
@@ -69,7 +73,7 @@ module Satone
           topic_title = topic_body.css('h1').text
           topic_body  = topic_body.css('p.linkurl').text
 
-          next unless is_target_information? topic_body
+          next unless is_target_information?(topic_title, topic_body)
           
           content = {
             title: topic_title,
@@ -86,10 +90,11 @@ module Satone
         { is_updated: is_updated, updates: updates }
       end
 
-      def self.is_target_information?(topic_body)
+      def self.is_target_information?(topic_title, topic_body)
         is_target_information = false
           
         LESSON_KEYWORDS.each do |lesson|
+          is_target_information = true if topic_title.include? lesson
           is_target_information = true if topic_body.include? lesson
         end        
 

--- a/spec/lib/satone/command/konami_alternate_notifier_spec.rb
+++ b/spec/lib/satone/command/konami_alternate_notifier_spec.rb
@@ -42,4 +42,39 @@ RSpec.describe Satone::Command::KonamiAlternateNotifier do
       it_behaves_like "common spec"
     end
   end
+
+  describe ".is_target_information?" do
+    subject { Satone::Command::KonamiAlternateNotifier.is_target_information? title, body }
+
+    shared_examples_for "common spec" do
+      it "returns expected result" do
+        expect(subject).to be expected_result
+      end
+    end
+    
+    context "title includes LESSON_KEYWORDS" do
+      let(:title) { "X55 hogehoge" }
+      let(:body) { "AA -> BB" }
+      let(:expected_result) { true }
+
+      it_behaves_like "common spec"
+    end
+
+    context "body includes LESSON_KEYWORDS" do
+      let(:title) { "hugahuga" }
+      let(:body) { "ボディパンプ AA -> BB" }
+      let(:expected_result) { true }
+
+      it_behaves_like "common spec"
+    end
+
+    context "neither title nor body includes LESSON_KEYWORDS" do
+      let(:title) { "piyopiyo" }
+      let(:body) { "水泳 AA -> BB" }
+      let(:expected_result) { false }
+
+      it_behaves_like "common spec"
+
+    end
+  end
 end

--- a/spec/lib/satone/command/konami_alternate_notifier_spec.rb
+++ b/spec/lib/satone/command/konami_alternate_notifier_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe Satone::Command::KonamiAlternateNotifier do
       let(:expected_result) { false }
 
       it_behaves_like "common spec"
-
     end
   end
 end


### PR DESCRIPTION
ついでに #6 の修正も入れた。