### PR TITLE
コナミの代行情報取得方法を修正

### DIFF
--- a/spec/lib/satone/command/konami_alternate_notifier_spec.rb
+++ b/spec/lib/satone/command/konami_alternate_notifier_spec.rb
@@ -51,29 +51,40 @@ RSpec.describe Satone::Command::KonamiAlternateNotifier do
         expect(subject).to be expected_result
       end
     end
-    
-    context "title includes LESSON_KEYWORDS" do
-      let(:title) { "X55 hogehoge" }
-      let(:body) { "AA -> BB" }
-      let(:expected_result) { true }
 
-      it_behaves_like "common spec"
-    end
-
-    context "body includes LESSON_KEYWORDS" do
-      let(:title) { "hugahuga" }
-      let(:body) { "ボディパンプ AA -> BB" }
-      let(:expected_result) { true }
-
-      it_behaves_like "common spec"
-    end
-
-    context "neither title nor body includes LESSON_KEYWORDS" do
-      let(:title) { "piyopiyo" }
-      let(:body) { "水泳 AA -> BB" }
+    context "title not includes TITLE_KEYWORDS" do
+      let(:title) { "【2017年1月～3月スタジオ予約参加対象クラス】" }
+      let(:body) { "hogehoge" }
       let(:expected_result) { false }
 
       it_behaves_like "common spec"
+    end
+
+
+    context "title includes TITLE_KEYWORDS" do
+      context "title includes LESSON_KEYWORDS" do
+        let(:title) { "X55 AA -> BB 代行" }
+        let(:body) { "" }
+        let(:expected_result) { true }
+
+        it_behaves_like "common spec"
+      end
+
+      context "body includes LESSON_KEYWORDS" do
+        let(:title) { "hugahuga 代行のご案内" }
+        let(:body) { "ボディパンプ AA -> BB" }
+        let(:expected_result) { true }
+
+        it_behaves_like "common spec"
+      end
+
+      context "neither title nor body includes LESSON_KEYWORDS" do
+        let(:title) { "piyopiyo 代行のご案内" }
+        let(:body) { "水泳 AA -> BB" }
+        let(:expected_result) { false }
+
+        it_behaves_like "common spec"
+      end
     end
   end
 end


### PR DESCRIPTION
スケジュールページの表示方法が変わったので、それに対応する。

**旧方法**

`http://information.konamisportsclub.jp/newdesign/timetable.php?Facility_cd=XXX` をGETで取得し、その後「タイムテーブル更新情報」のDOMをparseして、そこから各情報のURLをGETして内容を精査していた。

**新方法**

「タイムテーブル更新情報」の欄がAJAXで取ってくるように変更された。いつからかは分からない。

```shell
% curl -F facility_cd=004479 http://information.konamisportsclub.jp/newdesign/ajax/if_get_topic.php
```

こんな感じでやるとURLの生成に必要なパラメータだけが帰って来る。ここから得られたパラメータをトピックのURLをformatに埋め込んで、そのURL毎にGETして内容を精査するようにした。